### PR TITLE
Add full typescript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+doc/tags
+test/testresults.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 doc/tags
+test/**/*typescript.vader
 test/testresults.txt

--- a/autoload/htl_indent.vim
+++ b/autoload/htl_indent.vim
@@ -1,41 +1,45 @@
-" Description: Vim lit-html indent file
-" Language: JavaScript
+" Description: Vim html-template-string indent amendments
 " Maintainer: Jon Smithers <mail@jonsmithers.link>
 
-" Save the current JavaScript indentexpr.
-let b:litHtmlOriginalIndentExpression = &indentexpr
+function! htl_indent#amendIndentation(options)
+  let b:htl_options = a:options
 
-" import xml indent
-if exists('b:did_indent')
-  let s:did_indent=b:did_indent
-  unlet b:did_indent
-endif
-exe 'runtime! indent/html.vim'
-if exists('s:did_indent')
-  let b:did_indent=s:did_indent
-endif
+  " Save the current JavaScript indentexpr.
+  let b:litHtmlOriginalIndentExpression = &indentexpr
 
-" import css indent
-if exists('b:did_indent')
-  let s:did_indent=b:did_indent
-  unlet b:did_indent
-endif
-exe 'runtime! indent/css.vim'
-if exists('s:did_indent')
-  let b:did_indent=s:did_indent
-endif
+  " import html indent
+  if exists('b:did_indent')
+    let s:did_indent=b:did_indent
+    unlet b:did_indent
+  endif
+  exe 'runtime! indent/html.vim'
+  if exists('s:did_indent')
+    let b:did_indent=s:did_indent
+  endif
 
-setlocal indentexpr=ComputeLitHtmlIndent()
+  " import css indent
+  if exists('b:did_indent')
+    let s:did_indent=b:did_indent
+    unlet b:did_indent
+  endif
+  exe 'runtime! indent/css.vim'
+  if exists('s:did_indent')
+    let b:did_indent=s:did_indent
+  endif
 
-" JS indentkeys
-setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e
-" XML indentkeys
-setlocal indentkeys+=*<Return>,<>>,<<>,/
-" lit-html indentkeys
-setlocal indentkeys+=`
+  setlocal indentexpr=ComputeLitHtmlIndent()
 
-" Multiline end tag regex (line beginning with '>' or '/>')
-let s:endtag = '^\s*\/\?>\s*;\='
+  " JS indentkeys
+  setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e
+  " XML indentkeys
+  setlocal indentkeys+=*<Return>,<>>,<<>,/
+  " lit-html indentkeys
+  setlocal indentkeys+=`
+
+  " Multiline end tag regex (line beginning with '>' or '/>')
+  let s:endtag = '^\s*\/\?>\s*;\='
+
+endfunction
 
 " Get syntax stack at StartOfLine
 fu! s:VHTL_SynSOL(lnum)

--- a/autoload/htl_indent.vim
+++ b/autoload/htl_indent.vim
@@ -68,8 +68,8 @@ endfunction
 
 " Make debug log. You can view these logs using ':messages'
 fu! s:debug(str)
-  if (exists('g:VHTL_debugging') && g:VHTL_debugging == 1)
-    echom 'vhtl ' . v:lnum . ': ' . a:str
+  if (exists('g:htl_debug') && g:htl_debug == 1)
+    echom 'htl ' . v:lnum . ': ' . a:str
   endif
 endfu
 

--- a/autoload/htl_indent.vim
+++ b/autoload/htl_indent.vim
@@ -1,7 +1,7 @@
 " Description: Vim html-template-string indent amendments
 " Maintainer: Jon Smithers <mail@jonsmithers.link>
 
-function! htl_indent#amendIndentation(options)
+function! htl_indent#amend(options)
   let b:htl_options = a:options
 
   " Save the current JavaScript indentexpr.

--- a/autoload/htl_syntax.vim
+++ b/autoload/htl_syntax.vim
@@ -1,4 +1,4 @@
-function! htmltemplateliterals#amendSyntax(options)
+function! htl_syntax#amend(options)
   if exists('b:current_syntax')
     let s:current_syntax=b:current_syntax
     unlet b:current_syntax

--- a/autoload/htmltemplateliterals.vim
+++ b/autoload/htmltemplateliterals.vim
@@ -8,22 +8,17 @@ function! htmltemplateliterals#amendSyntax(options)
     let b:current_syntax=s:current_syntax
   endif
 
-  if (a:options.typescript == 1)
-    syntax region litHtmlRegion
-          \ contains=@HTMLSyntax,typescriptInterpolation
-          \ start=+html`+
-          \ skip=+\\`+
-          \ end=+`+
-          \ extend
-          \ keepend
-  else
-    syntax region litHtmlRegion
-          \ contains=@HTMLSyntax,jsTemplateExpression
-          \ start=+html`+
-          \ skip=+\\`+
-          \ end=+`+
-          \ extend
-          \ keepend
+  let l:all_templates=(exists('g:htl_all_templates') && g:htl_all_templates)
+  exec 'syntax region litHtmlRegion 
+        \ contains=@HTMLSyntax,' . (a:options.typescript ? 'typescriptInterpolation' : 'jsTemplateExpression') . '
+        \ start=' . (l:all_templates ? '+\(html\)\?`+' : '+html`+') . '
+        \ skip=+\\`+
+        \ end=+`+
+        \ extend
+        \ keepend
+        \ '
+  if (l:all_templates)
+    hi def link litHtmlRegion String
   endif
 
   if (a:options.typescript)

--- a/doc/html-template-literals.txt
+++ b/doc/html-template-literals.txt
@@ -1,0 +1,18 @@
+html-template-literals.txt
+
+HTML Template Literals                                  *html-template-literals*
+
+==============================================================================
+INTRODUCTION
+
+This plugin amends javascript or typescript syntax definitions to include an
+html template string region to be treated as html code. Syntax highlighting
+and auto-indentation inside these regions will mirror what you'd see in an
+html file.
+
+==============================================================================
+CONFIGURATION
+
+g:htl_all_templates                                        *g:htl_all_templates*
+
+  Experimental! Enables html syntax for ALL html template strings.

--- a/doc/html-template-literals.txt
+++ b/doc/html-template-literals.txt
@@ -6,9 +6,14 @@ HTML Template Literals                                  *html-template-literals*
 INTRODUCTION
 
 This plugin amends javascript or typescript syntax definitions to include an
-html template string region to be treated as html code. Syntax highlighting
-and auto-indentation inside these regions will mirror what you'd see in an
-html file.
+html template string region to be treated as html code. Syntax highlighting and
+auto-indentation inside these regions will mirror what you'd see for html code
+in an html file.
+
+There is compatibility only for the following syntax plugins:
+
+* pangloss/vim-javascript           https://github.com/pangloss/vim-javascript
+* leafgarland/typescript-vim     https://github.com/leafgarland/typescript-vim
 
 ==============================================================================
 CONFIGURATION

--- a/doc/html-template-literals.txt
+++ b/doc/html-template-literals.txt
@@ -1,23 +1,26 @@
 html-template-literals.txt
-
-HTML Template Literals                                  *html-template-literals*
-
+HTML TEMPLATE LITERALS       *vim-html-template-literals* *html-template-literals*
 ==============================================================================
-INTRODUCTION
 
 This plugin amends javascript or typescript syntax definitions to include an
-html template string region to be treated as html code. Syntax highlighting and
-auto-indentation inside these regions will mirror what you'd see for html code
-in an html file.
+html template string region to be treated as html code. Syntax highlighting
+and auto-indentation inside these regions will mirror what you'd see for html
+code in an html file.
 
 There is compatibility only for the following syntax plugins:
 
 * pangloss/vim-javascript           https://github.com/pangloss/vim-javascript
 * leafgarland/typescript-vim     https://github.com/leafgarland/typescript-vim
 
+
+CONFIGURATION                             *html-template-literals-configuration*
 ==============================================================================
-CONFIGURATION
 
 g:htl_all_templates                                        *g:htl_all_templates*
 
-  Experimental! Enables html syntax for ALL html template strings.
+    Experimental! Enables html syntax for ALL html template strings.
+
+g:htl_debug                                                        *g:htl_debug*
+
+    Log debugging information allowing you trace the code path used to indent
+    each line by viewing :messages.

--- a/plugin/html-template-literals.vim
+++ b/plugin/html-template-literals.vim
@@ -1,7 +1,7 @@
 augroup html-template-literals
   au!
-  autocmd FileType javascript,javascript.jsx call htmltemplateliterals#amendSyntax({'typescript': 0})
-  autocmd FileType javascript,javascript.jsx call htl_indent#amendIndentation({'typescript': 0})
-  autocmd FileType typescript                call htmltemplateliterals#amendSyntax({'typescript': 1})
-  autocmd FileType typescript                call htl_indent#amendIndentation({'typescript': 1})
+  autocmd FileType javascript,javascript.jsx call htl_syntax#amend({'typescript': 0})
+  autocmd FileType javascript,javascript.jsx call htl_indent#amend({'typescript': 0})
+  autocmd FileType typescript                call htl_syntax#amend({'typescript': 1})
+  autocmd FileType typescript                call htl_indent#amend({'typescript': 1})
 augroup END

--- a/plugin/html-template-literals.vim
+++ b/plugin/html-template-literals.vim
@@ -1,2 +1,7 @@
-autocmd FileType javascript,javascript.jsx call htmltemplateliterals#amendSyntax({'typescript': 0})
-autocmd FileType typescript                call htmltemplateliterals#amendSyntax({'typescript': 1})
+augroup html-template-literals
+  au!
+  autocmd FileType javascript,javascript.jsx call htmltemplateliterals#amendSyntax({'typescript': 0})
+  autocmd FileType javascript,javascript.jsx call htl_indent#amendIndentation({'typescript': 0})
+  autocmd FileType typescript                call htmltemplateliterals#amendSyntax({'typescript': 1})
+  autocmd FileType typescript                call htl_indent#amendIndentation({'typescript': 1})
+augroup END

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
-Syntax highlighting and indentation for
-[**lit-html**](https://github.com/Polymer/lit-html). Largely inspired by
-[**vim-jsx**](https://github.com/mxw/vim-jsx).
+# HTML Template Literals
+Syntax highlighting and indentation for html inside of tagged template
+literals, as seen in [lit-html](https://github.com/Polymer/lit-html) and
+[Polymer 3](https://polymer-library.polymer-project.org/3.0/docs/about_30).
 
 ## Supported Syntaxes inside ``html`...` ``
 - HTML (including CSS embedded in `<style>` tags)
@@ -10,22 +11,22 @@ Syntax highlighting and indentation for
 ## Installation
 
 This plugin requires
-[**vim-javascript**](https://github.com/pangloss/vim-javascript). If you use
-[**vim-plug**](https://github.com/junegunn/vim-plug) for package management,
-installation looks like this:
+[vim-javascript](https://github.com/pangloss/vim-javascript) (or
+[typescript-vim](https://github.com/leafgarland/typescript-vim) if you're using
+typescript). If you use [vim-plug](https://github.com/junegunn/vim-plug) for
+package management, installation looks like this:
 
 ```vim
-Plug 'jonsmithers/experimental-lit-html-vim'
+Plug 'jonsmithers/vim-html-template-literals'
 Plug 'pangloss/vim-javascript'
 ```
 
-Note: it's generally a good idea to have `let g:html_indent_style1 = "inc"` in
+_NOTE_: it's generally a good idea to have `let g:html_indent_style1 = "inc"` in
 your vimrc for reasonable indentation of `<style>` tags. See `:help
 html-indenting`.
 
 ## Known Issues
 
-- Indentation in TypeScript is not implemented yet.
 - Indentation in general still has some kinks. If you see an issue, please
   report it.
 - This plugin conflicts a bit with vim-jsx. Having both installed

--- a/test/minimalvimrc
+++ b/test/minimalvimrc
@@ -6,7 +6,7 @@ call plug#begin('~/.vim/plugged')
     Plug 'leafgarland/typescript-vim'
 call plug#end()
 syntax enable
-let g:VHTL_debugging = 1
+let g:htl_debug = 1
 let g:html_indent_style1 = "inc"
 
 nmap <F10> :echo map(synstack(line("."), col(".")), "synIDattr(v:val, 'name')")<cr>

--- a/test/minimalvimrc
+++ b/test/minimalvimrc
@@ -3,6 +3,7 @@ call plug#begin('~/.vim/plugged')
     Plug 'junegunn/vader.vim'
     Plug 'jonsmithers/vim-html-template-literals', { 'dir': '~/git/vim-html-template-literals' }
     Plug 'pangloss/vim-javascript'
+    Plug 'leafgarland/typescript-vim'
 call plug#end()
 syntax enable
 let g:VHTL_debugging = 1

--- a/test/runtests
+++ b/test/runtests
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
+
+rm ./**/*typescript.vader 2> /dev/null
+for javascriptTest in indent/*.vader; do
+  typescriptTest=$(echo "$javascriptTest" | sed -E 's/.vader$/-typescript.vader/')
+
+  cat > "$typescriptTest" <<- END_HEADER
+	=================================
+	== THIS FILE IS AUTO-GENERATED ==
+	=================================
+	END_HEADER
+
+  cat < "$javascriptTest" \
+    | sed -E 's/Given javascript/Given typescript/' \
+    | sed -E 's/Expect javascript/Expect typescript/' \
+    >> "$typescriptTest"
+done
 
 if [[ "$CI" = true ]]; then
   export VADER_OUTPUT_FILE='testresults.txt'


### PR DESCRIPTION
- Full typescript support
- Experimental `g:htl_all_templates` flag that enables html syntax in _all_ untagged string templates
- Rename `g:VHTL_debugging` option to `g:htl_debug`
- Add a help page