### PR TITLE
Add javascriptreact, typescriptreact filetypes

### DIFF
--- a/plugin/html-template-literals.vim
+++ b/plugin/html-template-literals.vim
@@ -1,7 +1,7 @@
 augroup html-template-literals
   au!
-  autocmd FileType javascript,javascript.jsx call htl_syntax#amend({'typescript': 0})
-  autocmd FileType javascript,javascript.jsx call htl_indent#amend({'typescript': 0})
-  autocmd FileType typescript                call htl_syntax#amend({'typescript': 1})
-  autocmd FileType typescript                call htl_indent#amend({'typescript': 1})
+  autocmd FileType javascript,javascriptreact,javascript.jsx call htl_syntax#amend({'typescript': 0})
+  autocmd FileType javascript,javascriptreact,javascript.jsx call htl_indent#amend({'typescript': 0})
+  autocmd FileType typescript,typescriptreact                call htl_syntax#amend({'typescript': 1})
+  autocmd FileType typescript,typescriptreact                call htl_indent#amend({'typescript': 1})
 augroup END


### PR DESCRIPTION
Apparently things moved to "javascriptreact" and "typescriptreact" instead of eg "typescript.jsx".  Some history on that is at https://github.com/vim/vim/issues/4830