### PR TITLE
Support templates in non-lithtml code

### DIFF
--- a/autoload/htl_syntax.vim
+++ b/autoload/htl_syntax.vim
@@ -35,7 +35,7 @@ function! htl_syntax#amend(options)
   exec 'syntax region litHtmlRegion
         \ contains=@HTMLSyntax,' . (a:options.typescript ? 'typescriptInterpolation,typescriptTemplateSubstitution' : 'jsTemplateExpression') . '
         \ containedin=typescriptBlock
-        \ start=' . (l:all_templates ? '+\(html\)\?`+' : '+html`+') . '
+        \ start=' . (l:all_templates ? '+\(html\)\?`+' : '+\(\/\*\s*\)\?html\(\s*\*\/\)\?`+') . '
         \ skip=+\\`+
         \ end=+`+
         \ extend
@@ -69,7 +69,7 @@ function! htl_syntax#amend(options)
   if (l:css_templates)
     exec 'syntax region cssLiteral
           \ contains=@CSSSyntax,' . (a:options.typescript ? 'typescriptInterpolation,typescriptTemplateSubstitution' : 'jsTemplateExpression') . '
-          \ start=+css`+
+          \ start=+\(\/\*\s*\)\?css\(\s*\*\/\)\?`+
           \ skip=+\\`+
           \ end=+`+
           \ extend


### PR DESCRIPTION
Hi Jon

I wanted your highlighting (thanks a lot!) but I don't use lithtml. So I adapted your "start" regexp to also parse "/* html */`" (and css). This syntax is taken from an atom plugin I've been using (https://github.com/vokeio/language-javascript-plus).

    Cheers
    Thorsten